### PR TITLE
Prevent making Personal Schedules in same quarter with duplicate names through edit 

### DIFF
--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
@@ -4,6 +4,7 @@ import PersonalScheduleForm from "main/components/PersonalSchedules/PersonalSche
 import { Navigate } from "react-router-dom";
 import { useBackend, useBackendMutation } from "main/utils/useBackend";
 import { Button } from "react-bootstrap";
+import { toast } from "react-toastify";
 
 export default function PersonalSchedulesEditPage() {
   const createButton = () => {
@@ -46,10 +47,13 @@ export default function PersonalSchedulesEditPage() {
       quarter: personalSchedule.quarter,
     },
   });
-
+  const onSuccess = () => {};
+  const onError = (error) => {
+    toast(`Error: ${error.response.data.message}`);
+  };
   const mutation = useBackendMutation(
     objectToAxiosParams,
-    {},
+    { onSuccess, onError },
     // Stryker disable next-line all : hard to set up test for caching
     [`/api/personalschedules/id=${id}`],
   );

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
@@ -243,6 +243,42 @@ describe("PersonalSchedulesEditPage tests", () => {
         </QueryClientProvider>,
       );
     });
+    test("when the backend returns an error, user gets toast with error message", async () => {
+      const queryClient = new QueryClient();
+      axiosMock
+        .onPut("/api/personalschedules")
+        .reply(500, { message: "The backend is in a mood today" });
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <PersonalSchedulesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      expect(
+        await screen.findByText("Edit Personal Schedule"),
+      ).toBeInTheDocument();
+
+      const nameField = screen.getByTestId("PersonalScheduleForm-name");
+      fireEvent.change(nameField, { target: { value: "Winter Courses" } });
+      const idField = screen.getByTestId("PersonalScheduleForm-id");
+      expect(idField).toBeInTheDocument();
+      expect(idField).toHaveValue("17");
+
+      const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
+
+      expect(submitButton).toBeInTheDocument();
+
+      fireEvent.click(submitButton);
+
+      await waitFor(() => expect(axiosMock.history.put.length).toBe(1));
+
+      expect(mockToast).toHaveBeenCalledWith(
+        "Error: The backend is in a mood today",
+      );
+    });
 
     test("renders without crashing for admin", () => {
       const queryClient = new QueryClient();

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesController.java
@@ -162,7 +162,14 @@ public class PersonalSchedulesController extends ApiController {
     personalschedule.setName(incomingSchedule.getName());
     personalschedule.setDescription(incomingSchedule.getDescription());
     personalschedule.setQuarter(incomingSchedule.getQuarter());
+    Optional<PersonalSchedule> existCheck =
+        personalscheduleRepository.findByUserAndNameAndQuarter(
+            currentUser, personalschedule.getName(), personalschedule.getQuarter());
 
+    if (existCheck.isPresent() && !(existCheck.get().getId() == id)) {
+      throw new IllegalArgumentException(
+          "A personal schedule with that name already exists in that quarter");
+    }
     personalscheduleRepository.save(personalschedule);
 
     return personalschedule;
@@ -184,7 +191,14 @@ public class PersonalSchedulesController extends ApiController {
     personalschedule.setName(incomingSchedule.getName());
     personalschedule.setDescription(incomingSchedule.getDescription());
     personalschedule.setQuarter(incomingSchedule.getQuarter());
+    Optional<PersonalSchedule> existCheck =
+        personalscheduleRepository.findByUserAndNameAndQuarter(
+            personalschedule.getUser(), personalschedule.getName(), personalschedule.getQuarter());
 
+    if (existCheck.isPresent() && !(existCheck.get().getId() == id)) {
+      throw new IllegalArgumentException(
+          "A personal schedule with that name already exists in that quarter");
+    }
     personalscheduleRepository.save(personalschedule);
 
     return personalschedule;

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesControllerTests.java
@@ -875,4 +875,201 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
     assertEquals(
         "A personal schedule with that name already exists in that quarter", json.get("message"));
   }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void cannot_edit_two_personal_schedules_to_have_same_name_and_quarter_with_diff_ids()
+      throws Exception {
+    // arrange
+
+    User thisUser = currentUserService.getCurrentUser().getUser();
+
+    PersonalSchedule existingSchedule =
+        PersonalSchedule.builder()
+            .name("TestName")
+            .description("uniquedescription1")
+            .quarter("20222")
+            .user(thisUser)
+            .id(0L)
+            .build();
+    PersonalSchedule conflictingNameSchedule =
+        PersonalSchedule.builder()
+            .name("ConflictingName")
+            .description("uniquedescription2")
+            .quarter("20222")
+            .user(thisUser)
+            .id(1L)
+            .build();
+    PersonalSchedule editedNameSchedule =
+        PersonalSchedule.builder()
+            .name("ConflictingName")
+            .description("uniquedescription1")
+            .quarter("20222")
+            .user(thisUser)
+            .id(0L)
+            .build();
+
+    when(personalscheduleRepository.findByIdAndUser(0L, thisUser))
+        .thenReturn(Optional.of(existingSchedule));
+    when(personalscheduleRepository.findByUserAndNameAndQuarter(
+            thisUser, "ConflictingName", "20222"))
+        .thenReturn(Optional.of(conflictingNameSchedule));
+    String requestBody = mapper.writeValueAsString(editedNameSchedule);
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/personalschedules?id=0")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isBadRequest())
+            .andReturn();
+
+    Map<String, Object> json = responseToJson(response);
+    assertEquals(
+        "A personal schedule with that name already exists in that quarter", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"ADMIN"})
+  @Test
+  public void cannot_edit_two_personal_schedules_to_have_same_name_and_quarter_with_diff_ids_admin()
+      throws Exception {
+    // arrange
+    User thisUser = currentUserService.getCurrentUser().getUser();
+    PersonalSchedule existingSchedule =
+        PersonalSchedule.builder()
+            .name("TestName")
+            .description("uniquedescription1")
+            .quarter("20222")
+            .user(thisUser)
+            .id(0L)
+            .build();
+    PersonalSchedule conflictingNameSchedule =
+        PersonalSchedule.builder()
+            .name("ConflictingName")
+            .description("uniquedescription2")
+            .quarter("20222")
+            .user(thisUser)
+            .id(1L)
+            .build();
+    PersonalSchedule editedNameSchedule =
+        PersonalSchedule.builder()
+            .name("ConflictingName")
+            .description("uniquedescription1")
+            .quarter("20222")
+            .user(thisUser)
+            .id(0L)
+            .build();
+
+    when(personalscheduleRepository.findById(0L)).thenReturn(Optional.of(existingSchedule));
+    when(personalscheduleRepository.findByUserAndNameAndQuarter(
+            thisUser, "ConflictingName", "20222"))
+        .thenReturn(Optional.of(conflictingNameSchedule));
+    String requestBody = mapper.writeValueAsString(editedNameSchedule);
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/personalschedules/admin?id=0")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isBadRequest())
+            .andReturn();
+
+    Map<String, Object> json = responseToJson(response);
+    assertEquals(
+        "A personal schedule with that name already exists in that quarter", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void can_edit_two_personal_schedules_to_have_same_name_and_quarter_with_same_ids()
+      throws Exception {
+    // arrange
+    User thisUser = currentUserService.getCurrentUser().getUser();
+
+    PersonalSchedule existingSchedule =
+        PersonalSchedule.builder()
+            .name("TestName")
+            .description("uniquedescription1")
+            .quarter("20222")
+            .user(thisUser)
+            .id(0L)
+            .build();
+    PersonalSchedule editedDescSchedule =
+        PersonalSchedule.builder()
+            .name("TestName")
+            .description("uniquedescription2")
+            .quarter("20222")
+            .user(thisUser)
+            .id(0L)
+            .build();
+
+    when(personalscheduleRepository.findByIdAndUser(0L, thisUser))
+        .thenReturn(Optional.of(existingSchedule));
+    when(personalscheduleRepository.findByUserAndNameAndQuarter(thisUser, "TestName", "20222"))
+        .thenReturn(Optional.of(existingSchedule));
+    String requestBody = mapper.writeValueAsString(editedDescSchedule);
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/personalschedules?id=0")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+    // assert
+    verify(personalscheduleRepository, times(1)).save(editedDescSchedule);
+    assertEquals(response.getResponse().getContentAsString(), requestBody);
+  }
+
+  @WithMockUser(roles = {"ADMIN"})
+  @Test
+  public void can_edit_two_personal_schedules_to_have_same_name_and_quarter_with_same_ids_admin()
+      throws Exception {
+    // arrange
+    User thisUser = currentUserService.getCurrentUser().getUser();
+    PersonalSchedule existingSchedule =
+        PersonalSchedule.builder()
+            .name("TestName")
+            .description("uniquedescription1")
+            .quarter("20222")
+            .user(thisUser)
+            .id(0L)
+            .build();
+    PersonalSchedule editedDescSchedule =
+        PersonalSchedule.builder()
+            .name("TestName")
+            .description("uniquedescription2")
+            .quarter("20222")
+            .user(thisUser)
+            .id(0L)
+            .build();
+
+    when(personalscheduleRepository.findById(0L)).thenReturn(Optional.of(existingSchedule));
+    when(personalscheduleRepository.findByUserAndNameAndQuarter(thisUser, "TestName", "20222"))
+        .thenReturn(Optional.of(existingSchedule));
+    String requestBody = mapper.writeValueAsString(editedDescSchedule);
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/personalschedules/admin?id=0")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+    // assert
+    verify(personalscheduleRepository, times(1)).save(editedDescSchedule);
+    assertEquals(response.getResponse().getContentAsString(), requestBody);
+  }
 }


### PR DESCRIPTION
closes #3
- Adds additional checks to prevent this edge case in the backend
- Adds better error message in the front end
- provides unit tests for both backend and frontend changes
Deployment can be tested [here](https://proj-courses-dev-berdly.dokku-02.cs.ucsb.edu/)!