### PR TITLE
Added Clear Job Logs button to AdminJobsPage

### DIFF
--- a/frontend/src/main/components/Jobs/ClearJobsForm.js
+++ b/frontend/src/main/components/Jobs/ClearJobsForm.js
@@ -1,0 +1,29 @@
+import { Form, Button, Container, Row, Col } from "react-bootstrap";
+
+const ClearJobsForm = ({ callback }) => {
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    callback();
+  };
+
+  // Stryker disable all : Stryker is testing by changing the padding to 0. But this is simply a visual optimization as it makes it look better
+  return (
+    <Form onSubmit={handleSubmit}>
+      <Container>
+        <Row style={{ paddingTop: 10, paddingBottom: 10 }}>
+          <Col md="auto">
+            <Button
+              variant="primary"
+              type="submit"
+              data-testid="clearJobsSubmit"
+            >
+              Clear
+            </Button>
+          </Col>
+        </Row>
+      </Container>
+    </Form>
+  );
+};
+
+export default ClearJobsForm;

--- a/frontend/src/main/pages/Admin/AdminJobsPage.js
+++ b/frontend/src/main/pages/Admin/AdminJobsPage.js
@@ -4,6 +4,7 @@ import JobsTable from "main/components/Jobs/JobsTable";
 import { useBackend } from "main/utils/useBackend";
 import Accordion from "react-bootstrap/Accordion";
 import TestJobForm from "main/components/Jobs/TestJobForm";
+import ClearJobsForm from "main/components/Jobs/ClearJobsForm";
 import UpdateGradeInfoForm from "main/components/Jobs/UpdateGradeInfoForm";
 
 import { useBackendMutation } from "main/utils/useBackend";
@@ -30,8 +31,11 @@ const AdminJobsPage = () => {
   const submitTestJob = async (data) => {
     testJobMutation.mutate(data);
   };
-
   // ***** update courses job *******
+  const objectToAxiosParamsClearJobs = () => ({
+    url: "/api/jobs/all",
+    method: "DELETE",
+  });
 
   const objectToAxiosParamsUpdateCoursesJob = (data) => ({
     url: `/api/jobs/launch/updateCourses?quarterYYYYQ=${data.quarter}&subjectArea=${data.subject}&ifStale=${data.ifStale}`,
@@ -54,11 +58,19 @@ const AdminJobsPage = () => {
   });
 
   // Stryker disable all
+
+  const clearJobsMutation = useBackendMutation(
+    objectToAxiosParamsClearJobs,
+    {},
+    ["/api/jobs/all"],
+  );
+
   const updateCoursesJobMutation = useBackendMutation(
     objectToAxiosParamsUpdateCoursesJob,
     {},
     ["/api/jobs/all"],
   );
+
   const updateCoursesByQuarterJobMutation = useBackendMutation(
     objectToAxiosParamsUpdateCoursesByQuarterJob,
     {},
@@ -77,6 +89,10 @@ const AdminJobsPage = () => {
     ["/api/jobs/all"],
   );
   // Stryker restore all
+
+  const clearJobs = async () => {
+    clearJobsMutation.mutate();
+  };
 
   const submitUpdateCoursesJob = async (data) => {
     updateCoursesJobMutation.mutate(data);
@@ -114,6 +130,10 @@ const AdminJobsPage = () => {
     {
       name: "Test Job",
       form: <TestJobForm submitAction={submitTestJob} />,
+    },
+    {
+      name: "Clear Job Logs",
+      form: <ClearJobsForm callback={clearJobs} />,
     },
     {
       name: "Update Courses Database",

--- a/frontend/src/tests/components/Jobs/ClearJobsForm.test.js
+++ b/frontend/src/tests/components/Jobs/ClearJobsForm.test.js
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router-dom";
+import ClearJobsForm from "main/components/Jobs/ClearJobsForm";
+import { QueryClient, QueryClientProvider } from "react-query";
+
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockedNavigate = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockedNavigate,
+}));
+
+const queryClient = new QueryClient();
+
+describe("ClearJobsForm tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  it("renders correctly", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <ClearJobsForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByText(/Clear/)).toBeInTheDocument();
+  });
+
+  test("renders without crashing when fallback values are used", async () => {
+    axiosMock.onGet("/api/systemInfo").reply(200, {
+      springH2ConsoleEnabled: false,
+      showSwaggerUILink: false,
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <ClearJobsForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    // Make sure the first and last options
+    expect(await screen.findByTestId("clearJobsSubmit")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/pages/AdminJobsPage.test.js
+++ b/frontend/src/tests/pages/AdminJobsPage.test.js
@@ -255,4 +255,30 @@ describe("AdminJobsPage tests", () => {
     await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
     expect(axiosMock.history.post[0].url).toBe(url);
   });
+
+  test("user can clear jobs", async () => {
+    const url = "/api/jobs/all";
+    axiosMock.onDelete(url).reply(200, {});
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AdminJobsPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText("Clear Job Logs")).toBeInTheDocument();
+
+    const dropDownButton = screen.getByText("Clear Job Logs");
+    expect(dropDownButton).toBeInTheDocument();
+    dropDownButton.click();
+
+    const clearJobsButton = screen.getByTestId("clearJobsSubmit");
+    expect(clearJobsButton).toBeInTheDocument();
+    clearJobsButton.click();
+
+    await waitFor(() => expect(axiosMock.history.delete.length).toBe(1));
+    expect(axiosMock.history.delete[0].url).toBe(url);
+  });
 });


### PR DESCRIPTION
closes #9 
Adds a button onto the Admin JobsPage which can be selected to clear all existing job logs on screen. The issue requested adding backend support through adding an endpoint to delete all jobs in the database, but thankfully, I found that the requested endpoint was already implemented in the repo. I only needed to add a single button.
To test, simply build this branch and login, run some jobs, and clear them!

Deployment can be tested [here](https://berdly-issue-9.dokku-02.cs.ucsb.edu/)

Additionally, I noticed that this implementation and the UpdateGradeInfoForm have an identical implementation. I believe it might be prudent to allow quicker creation of single button tasks like this by refactoring them to both be instances of one component. I've raised the issue in #21.