### PR TITLE
Added getActiveQuarters method to UCSBAPIQuarterService and /api/public/activeQuarters endpoint

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBAPIQuarterController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBAPIQuarterController.java
@@ -42,4 +42,10 @@ public class UCSBAPIQuarterController extends ApiController {
     List<UCSBAPIQuarter> savedQuarters = ucsbAPIQuarterService.loadAllQuarters();
     return savedQuarters;
   }
+
+  @Operation(summary = "Get list of active quarters")
+  @GetMapping(value = "/activeQuarters", produces = "application/json")
+  public List<String> activeQuarters() throws Exception {
+    return ucsbAPIQuarterService.getActiveQuarters();
+  }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/services/UCSBAPIQuarterService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/UCSBAPIQuarterService.java
@@ -160,8 +160,14 @@ public class UCSBAPIQuarterService {
 
   public List<String> getActiveQuarters() throws Exception {
     List<String> activeQuarters = new ArrayList<>();
-    Quarter.quarterList(getCurrentQuarterYYYYQ(), getEndQtrYYYYQ())
-        .forEach(quarter -> activeQuarters.add(quarter.getYYYYQ()));
+    String currQtr = getCurrentQuarterYYYYQ();
+    String endQtr = getEndQtrYYYYQ();
+
+    if (currQtr.compareTo(endQtr) <= 0) {
+      Quarter.quarterList(currQtr, endQtr)
+          .forEach(quarter -> activeQuarters.add(quarter.getYYYYQ()));
+    }
+
     return activeQuarters;
   }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/services/UCSBAPIQuarterService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/UCSBAPIQuarterService.java
@@ -3,6 +3,7 @@ package edu.ucsb.cs156.courses.services;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.courses.entities.UCSBAPIQuarter;
+import edu.ucsb.cs156.courses.models.Quarter;
 import edu.ucsb.cs156.courses.repositories.UCSBAPIQuarterRepository;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -155,5 +156,12 @@ public class UCSBAPIQuarterService {
         });
     log.info("savedQuarters.size={}", savedQuarters.size());
     return savedQuarters;
+  }
+
+  public List<String> getActiveQuarters() throws Exception {
+    List<String> activeQuarters = new ArrayList<>();
+    Quarter.quarterList(getCurrentQuarterYYYYQ(), getEndQtrYYYYQ())
+        .forEach(quarter -> activeQuarters.add(quarter.getYYYYQ()));
+    return activeQuarters;
   }
 }

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBAPIQuarterControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBAPIQuarterControllerTests.java
@@ -86,6 +86,25 @@ public class UCSBAPIQuarterControllerTests extends ControllerTestCase {
   }
 
   @Test
+  public void test_activeQuarters() throws Exception {
+
+    String url = "/api/public/activeQuarters";
+    List<String> activeQuarters = List.of("20242");
+    when(ucsbAPIQuarterService.getActiveQuarters()).thenReturn(activeQuarters);
+
+    MvcResult response =
+        mockMvc
+            .perform(get(url).contentType("application/json"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    assertEquals(
+        activeQuarters,
+        objectMapper.readValue(
+            response.getResponse().getContentAsString(), new TypeReference<List<String>>() {}));
+  }
+
+  @Test
   @WithMockUser(roles = {"ADMIN"})
   public void test_loadQuarters() throws Exception {
 

--- a/src/test/java/edu/ucsb/cs156/courses/services/UCSBAPIQuarterServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/services/UCSBAPIQuarterServiceTests.java
@@ -121,6 +121,27 @@ public class UCSBAPIQuarterServiceTests {
   }
 
   @Test
+  public void test_getActiveQuarters() throws Exception {
+    UCSBAPIQuarter sampleCurrent =
+        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_W21, UCSBAPIQuarter.class);
+    String expectedJSON = objectMapper.writeValueAsString(sampleCurrent);
+    String expectedURL = UCSBAPIQuarterService.CURRENT_QUARTER_ENDPOINT;
+    this.mockRestServiceServer
+        .expect(requestTo(expectedURL))
+        .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+        .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+        .andExpect(header("ucsb-api-version", "1.0"))
+        .andExpect(header("ucsb-api-key", apiKey))
+        .andRespond(withSuccess(expectedJSON, MediaType.APPLICATION_JSON));
+
+    List<String> expectedResult =
+        List.of("20211", "20212", "20213", "20214", "20221", "20222", "20223");
+    List<String> actualResult = service.getActiveQuarters();
+
+    assertEquals(expectedResult, actualResult);
+  }
+
+  @Test
   public void test_getAllQuarters_preloaded() throws Exception {
     UCSBAPIQuarter sampleQuarter =
         objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24, UCSBAPIQuarter.class);

--- a/src/test/java/edu/ucsb/cs156/courses/services/UCSBAPIQuarterServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/services/UCSBAPIQuarterServiceTests.java
@@ -142,6 +142,47 @@ public class UCSBAPIQuarterServiceTests {
   }
 
   @Test
+  public void test_getActiveQuarters_returns_no_past_quarters() throws Exception {
+    UCSBAPIQuarter sampleCurrent =
+        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24, UCSBAPIQuarter.class);
+    String expectedJSON = objectMapper.writeValueAsString(sampleCurrent);
+    String expectedURL = UCSBAPIQuarterService.CURRENT_QUARTER_ENDPOINT;
+    this.mockRestServiceServer
+        .expect(requestTo(expectedURL))
+        .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+        .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+        .andExpect(header("ucsb-api-version", "1.0"))
+        .andExpect(header("ucsb-api-key", apiKey))
+        .andRespond(withSuccess(expectedJSON, MediaType.APPLICATION_JSON));
+
+    List<String> expectedResult = List.of();
+    List<String> actualResult = service.getActiveQuarters();
+
+    assertEquals(expectedResult, actualResult);
+  }
+
+  @Test
+  public void test_getActiveQuarters_returns_one_value_when_current_equals_end() throws Exception {
+    UCSBAPIQuarter sampleCurrent =
+        objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24, UCSBAPIQuarter.class);
+    sampleCurrent.setQuarter("20223");
+    String expectedJSON = objectMapper.writeValueAsString(sampleCurrent);
+    String expectedURL = UCSBAPIQuarterService.CURRENT_QUARTER_ENDPOINT;
+    this.mockRestServiceServer
+        .expect(requestTo(expectedURL))
+        .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+        .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+        .andExpect(header("ucsb-api-version", "1.0"))
+        .andExpect(header("ucsb-api-key", apiKey))
+        .andRespond(withSuccess(expectedJSON, MediaType.APPLICATION_JSON));
+
+    List<String> expectedResult = List.of("20223");
+    List<String> actualResult = service.getActiveQuarters();
+
+    assertEquals(expectedResult, actualResult);
+  }
+
+  @Test
   public void test_getAllQuarters_preloaded() throws Exception {
     UCSBAPIQuarter sampleQuarter =
         objectMapper.readValue(UCSBAPIQuarter.SAMPLE_QUARTER_JSON_M24, UCSBAPIQuarter.class);


### PR DESCRIPTION
closes #5
Adds the requested functionality, cleanly in terms of existing methods!
The endpoint can be entered directly into the browser to test the result!
The deployment can be accessed [here](https://berdly-issue-5.dokku-02.cs.ucsb.edu/)