### PR TITLE
Get job by ID added to controller file

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
@@ -1,8 +1,10 @@
 package edu.ucsb.cs156.courses.controllers;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
 import edu.ucsb.cs156.courses.entities.Job;
+import edu.ucsb.cs156.courses.errors.EntityNotFoundException;
 import edu.ucsb.cs156.courses.jobs.TestJob;
 import edu.ucsb.cs156.courses.jobs.UpdateCourseDataJobFactory;
 import edu.ucsb.cs156.courses.jobs.UploadGradeDataJob;
@@ -22,8 +24,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import edu.ucsb.cs156.courses.errors.EntityNotFoundException;
 
 @Tag(name = "Jobs")
 @RequestMapping("/api/jobs")
@@ -62,16 +62,14 @@ public class JobsController extends ApiController {
   @PreAuthorize("hasRole('ROLE_ADMIN')")
   @GetMapping("")
   public Job getJobLogById(
-      @Parameter(name = "id", description = "ID of the job") @RequestParam Long id) 
+      @Parameter(name = "id", description = "ID of the job") @RequestParam Long id)
       throws JsonProcessingException {
 
-    Job job = 
-      jobsRepository
-          .findById(id)
-          .orElseThrow(() -> new EntityNotFoundException(Job.class, id));
+    Job job =
+        jobsRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(Job.class, id));
 
     return job;
-}
+  }
 
   @Operation(summary = "Delete specific job record")
   @PreAuthorize("hasRole('ROLE_ADMIN')")

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
@@ -23,6 +23,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import edu.ucsb.cs156.courses.errors.EntityNotFoundException;
+
 @Tag(name = "Jobs")
 @RequestMapping("/api/jobs")
 @RestController
@@ -55,6 +58,20 @@ public class JobsController extends ApiController {
     jobsRepository.deleteAll();
     return Map.of("message", "All jobs deleted");
   }
+
+  @Operation(summary = "Get a specific Job Log by ID if it is in the database")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @GetMapping("")
+  public Job getJobLogById(
+      @Parameter(name = "id", description = "ID of the job") @RequestParam Long id) 
+      throws JsonProcessingException {
+
+    Job job = jobsRepository
+        .findById(id)
+        .orElseThrow(() -> new EntityNotFoundException(Job.class, id));
+
+    return job;
+}
 
   @Operation(summary = "Delete specific job record")
   @PreAuthorize("hasRole('ROLE_ADMIN')")

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
@@ -65,9 +65,10 @@ public class JobsController extends ApiController {
       @Parameter(name = "id", description = "ID of the job") @RequestParam Long id) 
       throws JsonProcessingException {
 
-    Job job = jobsRepository
-        .findById(id)
-        .orElseThrow(() -> new EntityNotFoundException(Job.class, id));
+    Job job = 
+      jobsRepository
+          .findById(id)
+          .orElseThrow(() -> new EntityNotFoundException(Job.class, id));
 
     return job;
 }

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
@@ -22,7 +22,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import edu.ucsb.cs156.courses.errors.EntityNotFoundException;
 

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/JobsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/JobsControllerTests.java
@@ -37,6 +37,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
+import java.util.Optional;
 
 @Slf4j
 @WebMvcTest(controllers = JobsController.class)
@@ -87,6 +88,59 @@ public class JobsControllerTests extends ControllerTestCase {
     String responseString = response.getResponse().getContentAsString();
     assertEquals(expectedJson, responseString);
   }
+
+  @WithMockUser(roles = {"ADMIN"})
+  @Test
+  public void api_getJobLogById__admin_logged_in__returns_job_by_id() throws Exception {
+
+      // arrange
+      
+      Job job = Job.builder()
+              .id(1L)
+              .status("completed")
+              .log("This is a test job log.")
+              .build();
+
+      when(jobsRepository.findById(eq(1L))).thenReturn(Optional.of(job));
+
+      // act
+
+      MvcResult response = mockMvc
+              .perform(get("/api/jobs?id=1"))
+              .andExpect(status().isOk())
+              .andReturn();
+
+      // assert
+
+      verify(jobsRepository, times(1)).findById(1L);
+      String expectedJson = mapper.writeValueAsString(job);
+      String responseString = response.getResponse().getContentAsString();
+      assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN"})
+  @Test
+  public void api_getJobLogById__admin_logged_in__returns_not_found_for_missing_job() throws Exception {
+
+      // arrange
+
+      when(jobsRepository.findById(eq(2L))).thenReturn(Optional.empty());
+
+      // act
+
+      MvcResult response = mockMvc
+              .perform(get("/api/jobs?id=2"))
+              .andExpect(status().isNotFound())
+              .andReturn();
+
+      // assert
+
+      verify(jobsRepository, times(1)).findById(2L);
+      Map<String, Object> json = responseToJson(response);
+      assertEquals("EntityNotFoundException", json.get("type"));
+      assertEquals("Job with id 2 not found", json.get("message"));
+  }
+
 
   @WithMockUser(roles = {"ADMIN"})
   @Test

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/JobsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/JobsControllerTests.java
@@ -28,6 +28,7 @@ import edu.ucsb.cs156.courses.services.jobs.JobService;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,7 +38,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
-import java.util.Optional;
 
 @Slf4j
 @WebMvcTest(controllers = JobsController.class)
@@ -93,54 +93,46 @@ public class JobsControllerTests extends ControllerTestCase {
   @Test
   public void api_getJobLogById__admin_logged_in__returns_job_by_id() throws Exception {
 
-      // arrange
-      
-      Job job = Job.builder()
-              .id(1L)
-              .status("completed")
-              .log("This is a test job log.")
-              .build();
+    // arrange
 
-      when(jobsRepository.findById(eq(1L))).thenReturn(Optional.of(job));
+    Job job = Job.builder().id(1L).status("completed").log("This is a test job log.").build();
 
-      // act
+    when(jobsRepository.findById(eq(1L))).thenReturn(Optional.of(job));
 
-      MvcResult response = mockMvc
-              .perform(get("/api/jobs?id=1"))
-              .andExpect(status().isOk())
-              .andReturn();
+    // act
 
-      // assert
+    MvcResult response =
+        mockMvc.perform(get("/api/jobs?id=1")).andExpect(status().isOk()).andReturn();
 
-      verify(jobsRepository, times(1)).findById(1L);
-      String expectedJson = mapper.writeValueAsString(job);
-      String responseString = response.getResponse().getContentAsString();
-      assertEquals(expectedJson, responseString);
+    // assert
+
+    verify(jobsRepository, times(1)).findById(1L);
+    String expectedJson = mapper.writeValueAsString(job);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
   }
 
   @WithMockUser(roles = {"ADMIN"})
   @Test
-  public void api_getJobLogById__admin_logged_in__returns_not_found_for_missing_job() throws Exception {
+  public void api_getJobLogById__admin_logged_in__returns_not_found_for_missing_job()
+      throws Exception {
 
-      // arrange
+    // arrange
 
-      when(jobsRepository.findById(eq(2L))).thenReturn(Optional.empty());
+    when(jobsRepository.findById(eq(2L))).thenReturn(Optional.empty());
 
-      // act
+    // act
 
-      MvcResult response = mockMvc
-              .perform(get("/api/jobs?id=2"))
-              .andExpect(status().isNotFound())
-              .andReturn();
+    MvcResult response =
+        mockMvc.perform(get("/api/jobs?id=2")).andExpect(status().isNotFound()).andReturn();
 
-      // assert
+    // assert
 
-      verify(jobsRepository, times(1)).findById(2L);
-      Map<String, Object> json = responseToJson(response);
-      assertEquals("EntityNotFoundException", json.get("type"));
-      assertEquals("Job with id 2 not found", json.get("message"));
+    verify(jobsRepository, times(1)).findById(2L);
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("EntityNotFoundException", json.get("type"));
+    assertEquals("Job with id 2 not found", json.get("message"));
   }
-
 
   @WithMockUser(roles = {"ADMIN"})
   @Test


### PR DESCRIPTION
Part of larger epic issue #8. Adds a GET method by id to retrieve a specific job by id. Was not included in legacy repo other than a GET all function. Used in loading a single log if lines exceed 10 lines for issue #8.

Testing:

- Test on swagger to make sure a pre-existing job can be searched and is returned properly
- Error is thrown if non-existent job is queried

Deployment Link: 
https://proj-courses-dev-vedp3705.dokku-02.cs.ucsb.edu/